### PR TITLE
Change sys.path for Sphinx autodoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,9 +13,12 @@
 import os
 import sys
 
-from sphinx.ext.autodoc import ClassLevelDocumenter, InstanceAttributeDocumenter
+from sphinx.ext.autodoc import (
+    ClassLevelDocumenter,
+    InstanceAttributeDocumenter,
+)
 
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("../.."))
 
 
 # XXX: Monkey-patch to remove `=None` from attribute annotations.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ from sphinx.ext.autodoc import (
     InstanceAttributeDocumenter,
 )
 
-sys.path.insert(0, os.path.abspath("../.."))
+sys.path.insert(0, os.path.abspath(".."))
 
 
 # XXX: Monkey-patch to remove `=None` from attribute annotations.


### PR DESCRIPTION
In case anyone finds this: to use Vercel with Sphinx via a separate `docs` folder, the following settings work:

Build command: `cd docs && pip install -r requirements.txt && make html`
Output directory: `docs/_build/html`
Root directory: `./`